### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -104,7 +104,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt OriginRequestFunctionRole.Arn
       Timeout: 5
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
 
   OriginRequestFunctionVersion:
     Type: "AWS::Lambda::Version"
@@ -161,7 +161,7 @@ Resources:
       Handler: index.handler
       Role: !GetAtt DeployFunctionRole.Arn
       Timeout: 300
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
 
   DeployArtifacts:
     Type: 'Custom::LambdaCallout'


### PR DESCRIPTION
CloudFormation templates in aws-lambda-redirection-at-edge have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.